### PR TITLE
🌟 Adicionar o grid de movimento com restrição

### DIFF
--- a/Assets/BattleUnit.cs
+++ b/Assets/BattleUnit.cs
@@ -16,25 +16,44 @@ public class BattleUnit : MonoBehaviour
         unit = unitSO.character;
     }
 
-    // Update is called once per frame
-    void Update()
+    private void OnMouseDown()
     {
-        if (Input.GetMouseButtonDown(0))
-        {
-            RaycastHit hit;
-            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+        RaycastHit hit;
+        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
 
-            if (Physics.Raycast(ray, out hit, 100f))
+        if (Physics.Raycast(ray, out hit, 100f))
+        {
+            BattleUnit hitUnit = hit.transform.GetComponent<BattleUnit>();
+            if (hitUnit != null)
             {
-                BattleUnit hitUnit = hit.transform.GetComponent<BattleUnit>();
-                if (hitUnit != null)
+                Character character = hitUnit.GetUnit();
+                Debug.Log(character.unitName);
+                battleSystem.SetSelectedUnit(hitUnit);
+
+                BattleGrid.Instance.ResetGridState();
+
+                for (int x = (int)(battleFieldPosition.x - character.movement); x <= (int)(battleFieldPosition.x + character.movement); x++)
                 {
-                    Debug.Log(hitUnit.GetUnit());
-                    battleSystem.SetSelectedUnit(hitUnit);
+                    for (int z = (int)(battleFieldPosition.y - character.movement); z <= (int)(battleFieldPosition.y + character.movement); z++)
+                    {
+                        // Manhattan Distance formula
+                        int AbsX = (int) Mathf.Abs(battleFieldPosition.x - x);
+                        int AbsZ = (int) Mathf.Abs(battleFieldPosition.y - z);
+
+                        if (AbsX + AbsZ <= character.movement && BattleGrid.Instance.WithinGridBounding(new Vector2(x, z)))
+                        {
+                            BattleTile tile = BattleGrid.Instance.GetTileAtPosition(new Vector2(x, z));
+                            tile.SetState(TileState.Movement);
+                        }
+                    }
                 }
             }
         }
+    }
 
+    // Update is called once per frame
+    void Update()
+    {
         BattleTile battleTile = BattleGrid.Instance.GetTileAtPosition(battleFieldPosition);
         this.transform.position = battleTile.transform.position;
     }

--- a/Assets/BattleUnit.cs
+++ b/Assets/BattleUnit.cs
@@ -58,6 +58,34 @@ public class BattleUnit : MonoBehaviour
         this.transform.position = battleTile.transform.position;
     }
 
+    public bool CanMoveTo(Vector2 position)
+    {
+        Character character = GetUnit();
+
+        bool canMoveToTile = false;
+        for (int x = (int)(battleFieldPosition.x - character.movement); x <= (int)(battleFieldPosition.x + character.movement); x++)
+        {
+            for (int z = (int)(battleFieldPosition.y - character.movement); z <= (int)(battleFieldPosition.y + character.movement); z++)
+            {
+                // Manhattan Distance formula
+                int AbsX = (int)Mathf.Abs(battleFieldPosition.x - x);
+                int AbsZ = (int)Mathf.Abs(battleFieldPosition.y - z);
+
+                if (AbsX + AbsZ <= character.movement && BattleGrid.Instance.WithinGridBounding(new Vector2(x, z)))
+                {
+                    BattleTile tile = BattleGrid.Instance.GetTileAtPosition(new Vector2(x, z));
+                    
+                    if (tile && tile.GetPosition() == position)
+                    {
+                        canMoveToTile = true;
+                    }
+                }
+            }
+        }
+
+        return canMoveToTile;
+    }
+
     public void SetBattleFieldPosition (Vector2 position)
     {
         battleFieldPosition = position;

--- a/Assets/Objects/BattleGrid/BattleGrid.cs
+++ b/Assets/Objects/BattleGrid/BattleGrid.cs
@@ -62,6 +62,36 @@ public class BattleGrid : MonoBehaviour
         }
     }
 
+    public float GetGridWidth()
+    {
+        return _width;
+    }
+
+    public float GetGridHeight ()
+    {
+        return _height;
+    }
+
+    public void ResetGridState ()
+    {
+        for (int x = 0; x < _width; x++)
+        {
+            for (int y = 0; y < _height; y++)
+            {
+                BattleTile tile = GetTileAtPosition(new Vector2(x, y));
+                tile.SetState(TileState.Transparent);
+            }
+        }
+    }
+
+    public bool WithinGridBounding (Vector2 pos)
+    {
+        bool withinX = 0f <= pos.x && pos.x < _width;
+        bool withinY = 0f <= pos.y && pos.y < _height;
+
+        return withinX && withinY;
+    }
+
     public BattleTile GetTileAtPosition (Vector2 position)
     {
         if (_tiles.TryGetValue(position, out BattleTile tile))

--- a/Assets/Objects/BattleTile/BattleTile.cs
+++ b/Assets/Objects/BattleTile/BattleTile.cs
@@ -22,10 +22,6 @@ public class BattleTile : MonoBehaviour
 
     [SerializeField] Vector2 position;
 
-    [SerializeField] bool walkable;
-
-    //[SerializeField] string[] = System.Enum.Get
-
     // Start is called before the first frame update
     void Start()
     {
@@ -70,12 +66,6 @@ public class BattleTile : MonoBehaviour
             BattleGrid.Instance.ResetGridState();
         }
     }
-
-    public bool isWalkable ()
-    {
-        return walkable;
-    }
-
     public void OnMouseEnter()
     {
         HighlightGameObject.SetActive(true);

--- a/Assets/Objects/BattleTile/BattleTile.cs
+++ b/Assets/Objects/BattleTile/BattleTile.cs
@@ -22,6 +22,8 @@ public class BattleTile : MonoBehaviour
 
     [SerializeField] Vector2 position;
 
+    [SerializeField] bool walkable;
+
     //[SerializeField] string[] = System.Enum.Get
 
     // Start is called before the first frame update
@@ -49,6 +51,11 @@ public class BattleTile : MonoBehaviour
         }
     }
 
+    public Vector2 GetPosition ()
+    {
+        return position;
+    }
+
     public void SetPosition(Vector2 position)
     {
         this.position = position;
@@ -57,8 +64,16 @@ public class BattleTile : MonoBehaviour
     public void OnMouseDown()
     {
         BattleUnit battleUnit = BattleSystem.Instance.GetSelectedUnit();
-        battleUnit.SetBattleFieldPosition(this.position);
-        BattleGrid.Instance.ResetGridState();
+        if (battleUnit.CanMoveTo(this.position))
+        {
+            battleUnit.SetBattleFieldPosition(this.position);
+            BattleGrid.Instance.ResetGridState();
+        }
+    }
+
+    public bool isWalkable ()
+    {
+        return walkable;
     }
 
     public void OnMouseEnter()

--- a/Assets/Objects/BattleTile/BattleTile.cs
+++ b/Assets/Objects/BattleTile/BattleTile.cs
@@ -58,6 +58,7 @@ public class BattleTile : MonoBehaviour
     {
         BattleUnit battleUnit = BattleSystem.Instance.GetSelectedUnit();
         battleUnit.SetBattleFieldPosition(this.position);
+        BattleGrid.Instance.ResetGridState();
     }
 
     public void OnMouseEnter()

--- a/Assets/Resources/Characters/Goblin.asset
+++ b/Assets/Resources/Characters/Goblin.asset
@@ -20,5 +20,5 @@ MonoBehaviour:
     maxMp: 20
     currentMp: 10
     level: 1
-    movement: 1
+    movement: 3
     portrait: {fileID: 21300000, guid: f68065fa030e60e46acfb2371fc33141, type: 3}

--- a/Assets/Resources/Characters/Ogron.asset
+++ b/Assets/Resources/Characters/Ogron.asset
@@ -20,4 +20,5 @@ MonoBehaviour:
     maxMp: 0
     currentMp: 0
     level: 1
+    movement: 3
     portrait: {fileID: 21300000, guid: 2439dc29b44a4754986384b647042bb5, type: 3}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2281,7 +2281,7 @@ PrefabInstance:
     - target: {fileID: 8677338200847797335, guid: 25c922594cf2d914cbdb291b7c735d46,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -35.96
+      value: -10.3
       objectReference: {fileID: 0}
     - target: {fileID: 8677338200847797335, guid: 25c922594cf2d914cbdb291b7c735d46,
         type: 3}
@@ -2424,7 +2424,7 @@ MonoBehaviour:
     portrait: {fileID: 0}
   unitSO: {fileID: 11400000, guid: 426d2015f23c25244b47f60946f12ff3, type: 2}
   battleSystem: {fileID: 1102162756}
-  battleFieldPosition: {x: 3, y: 0}
+  battleFieldPosition: {x: 7, y: 0}
 --- !u!65 &991475729
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -2643,7 +2643,7 @@ MonoBehaviour:
     portrait: {fileID: 0}
   unitSO: {fileID: 11400000, guid: 9ccd05d32989c8047839b059c40aa623, type: 2}
   battleSystem: {fileID: 1102162756}
-  battleFieldPosition: {x: 4, y: 7}
+  battleFieldPosition: {x: 3, y: 4}
 --- !u!65 &1175628756
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -4997,7 +4997,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 2f72565c1758f634e86c17977e087018,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -28.95
+      value: -34.65
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 2f72565c1758f634e86c17977e087018,
         type: 3}
@@ -5007,7 +5007,7 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 2f72565c1758f634e86c17977e087018,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -9.6
+      value: -27.96
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 2f72565c1758f634e86c17977e087018,
         type: 3}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2151,7 +2151,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 26
+  orthographic size: 29
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -5226,7 +5226,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 124.995026, y: -136.3873}
-  m_SizeDelta: {x: 250, y: 250}
+  m_SizeDelta: {x: 220, y: 220}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2040254345
 MonoBehaviour:


### PR DESCRIPTION
# 🌟 Adicionar o grid de movimento com restrição

Esse Pull Request adiciona o Grid visual movimento baseado no atributo de movimento do personagem, e adiciona uma lógica que passa a restringir o dos personagens de se moverem apenas nos quadrados permitidos.

## Vídeo

<p>Unity 2019.4.17f1 Personal  - into-the-dungeon - SampleScene - PC, Mac &amp; Linux Standalone - Unity 2019.4.17f1 Personal  - 23 August 2022 - Watch Video</p>
<a href="https://www.loom.com/share/55b5ff20e0f140f980e66933f102a2c5">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/55b5ff20e0f140f980e66933f102a2c5-with-play.gif">
  </a>